### PR TITLE
feat: add authentication middleware

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,8 @@
+function ensureAuth(req, res, next) {
+  if (!req.session || !req.session.user) {
+    return res.redirect('/login');
+  }
+  next();
+}
+
+module.exports = { ensureAuth };

--- a/server.js
+++ b/server.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const session = require('express-session');
+const { ensureAuth } = require('./middleware/auth');
+
+const app = express();
+
+app.use(session({
+  secret: 'keyboard cat',
+  resave: false,
+  saveUninitialized: false
+}));
+
+app.get('/auction/new', ensureAuth, (req, res) => {
+  res.send('New auction form');
+});
+
+app.post('/auction/:id/bid', ensureAuth, (req, res) => {
+  res.send(`Bid placed on auction ${req.params.id}`);
+});
+
+module.exports = app;


### PR DESCRIPTION
## Summary
- add ensureAuth middleware to redirect unauthenticated users to /login
- protect auction routes with ensureAuth middleware

## Testing
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_68a10d55991083289847169706a33e24