### PR TITLE
Add auction start time, category, and status

### DIFF
--- a/migrations/002_add_category_start_status.sql
+++ b/migrations/002_add_category_start_status.sql
@@ -1,0 +1,4 @@
+ALTER TABLE auctions
+    ADD COLUMN category TEXT,
+    ADD COLUMN start_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ADD COLUMN status TEXT CHECK (status IN ('pending','active','closed')) NOT NULL DEFAULT 'pending';

--- a/src/auctions.js
+++ b/src/auctions.js
@@ -1,0 +1,38 @@
+const db = require('./db');
+
+async function createAuction({ title, description, user_id, end_at, category }) {
+  const query = `
+    INSERT INTO auctions (title, description, user_id, category, start_at, end_at, status)
+    VALUES ($1, $2, $3, $4, NOW(), $5, 'active')
+    RETURNING id, title, description, user_id, category, start_at, end_at, status;
+  `;
+  const params = [title, description, user_id, category, end_at];
+  const { rows } = await db.query(query, params);
+  return rows[0];
+}
+
+async function getActiveAuctions() {
+  const query = `
+    SELECT id, title, description, user_id, category, start_at, end_at, status
+    FROM auctions
+    WHERE status = 'active' AND end_at > NOW();
+  `;
+  const { rows } = await db.query(query);
+  return rows;
+}
+
+async function getAuctionsByUser(userId) {
+  const query = `
+    SELECT id, title, description, user_id, category, start_at, end_at, status
+    FROM auctions
+    WHERE user_id = $1 AND end_at > NOW();
+  `;
+  const { rows } = await db.query(query, [userId]);
+  return rows;
+}
+
+module.exports = {
+  createAuction,
+  getActiveAuctions,
+  getAuctionsByUser
+};

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,7 @@
+const { Pool } = require('pg');
+
+const pool = new Pool();
+
+module.exports = {
+  query: (text, params) => pool.query(text, params)
+};


### PR DESCRIPTION
## Summary
- add migration to introduce category, start_at, and status fields on auctions table
- track auction start and category in createAuction and related queries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a10e0663748328bb1c9a93630a3c04