### PR TITLE
feat: expand auction creation and seed data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "ejs": "^3.1.9",
         "express": "^4.18.2",
         "express-session": "^1.17.3",
-        "helmet": "^7.0.0"
+        "helmet": "^7.0.0",
+        "pg": "^8.16.3"
       },
       "devDependencies": {
         "nodemon": "^3.0.1"
@@ -1055,6 +1056,95 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1072,6 +1162,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -1345,6 +1474,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -1465,6 +1603,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "ejs": "^3.1.9",
     "express": "^4.18.2",
     "express-session": "^1.17.3",
-    "helmet": "^7.0.0"
+    "helmet": "^7.0.0",
+    "pg": "^8.16.3"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/seed.js
+++ b/seed.js
@@ -1,0 +1,92 @@
+const db = require('./src/db');
+const { createAuction } = require('./src/auctions');
+
+async function seed() {
+  try {
+    // Clear existing data
+    await db.query('DELETE FROM bids');
+    await db.query('DELETE FROM auctions');
+    await db.query('DELETE FROM users');
+
+    // Users
+    const users = await Promise.all([
+      db.query("INSERT INTO users (username, email) VALUES ($1, $2) RETURNING id", ['alice', 'alice@example.com']),
+      db.query("INSERT INTO users (username, email) VALUES ($1, $2) RETURNING id", ['bob', 'bob@example.com']),
+      db.query("INSERT INTO users (username, email) VALUES ($1, $2) RETURNING id", ['carol', 'carol@example.com'])
+    ]);
+    const [alice, bob, carol] = users.map(r => r.rows[0].id);
+
+    const now = new Date();
+    const auctions = [];
+    auctions.push(await createAuction({
+      title: 'Vintage Phone',
+      description: 'Old but gold',
+      user_id: alice,
+      category: 'electronics',
+      image_url: 'https://example.com/phone.jpg',
+      start_at: now,
+      end_at: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000),
+      reserve_price: 100,
+      buy_now_price: 200
+    }));
+    auctions.push(await createAuction({
+      title: 'Classic Book',
+      description: 'A timeless read',
+      user_id: bob,
+      category: 'books',
+      image_url: 'https://example.com/book.jpg',
+      start_at: now,
+      end_at: new Date(now.getTime() + 5 * 24 * 60 * 60 * 1000),
+      reserve_price: 50,
+      buy_now_price: null
+    }));
+    auctions.push(await createAuction({
+      title: 'Designer Shirt',
+      description: 'Fashion statement',
+      user_id: carol,
+      category: 'fashion',
+      image_url: 'https://example.com/shirt.jpg',
+      start_at: now,
+      end_at: new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000),
+      reserve_price: null,
+      buy_now_price: 150
+    }));
+    auctions.push(await createAuction({
+      title: 'Rare Coin',
+      description: 'Collector\'s item',
+      user_id: alice,
+      category: 'collectibles',
+      image_url: 'https://example.com/coin.jpg',
+      start_at: now,
+      end_at: new Date(now.getTime() + 10 * 24 * 60 * 60 * 1000),
+      reserve_price: 300,
+      buy_now_price: 500
+    }));
+    auctions.push(await createAuction({
+      title: 'Gaming Console',
+      description: 'Next-gen console',
+      user_id: bob,
+      category: 'gaming',
+      image_url: 'https://example.com/console.jpg',
+      start_at: now,
+      end_at: new Date(now.getTime() + 2 * 24 * 60 * 60 * 1000),
+      reserve_price: null,
+      buy_now_price: 400
+    }));
+
+    // Bids
+    await db.query("INSERT INTO bids (auction_id, user_id, amount, created_at) VALUES ($1,$2,$3,NOW())", [auctions[0].id, bob, 120]);
+    await db.query("INSERT INTO bids (auction_id, user_id, amount, created_at) VALUES ($1,$2,$3,NOW())", [auctions[0].id, carol, 130]);
+    await db.query("INSERT INTO bids (auction_id, user_id, amount, created_at) VALUES ($1,$2,$3,NOW())", [auctions[1].id, carol, 60]);
+    await db.query("INSERT INTO bids (auction_id, user_id, amount, created_at) VALUES ($1,$2,$3,NOW())", [auctions[2].id, alice, 140]);
+    await db.query("INSERT INTO bids (auction_id, user_id, amount, created_at) VALUES ($1,$2,$3,NOW())", [auctions[3].id, bob, 350]);
+
+    console.log('Seed data inserted');
+  } catch (err) {
+    console.error('Error seeding database', err);
+  } finally {
+    process.exit();
+  }
+}
+
+seed();

--- a/src/auctions.js
+++ b/src/auctions.js
@@ -1,19 +1,52 @@
 const db = require('./db');
 
-async function createAuction({ title, description, user_id, end_at, category }) {
+async function createAuction({
+  title,
+  description,
+  user_id,
+  category,
+  image_url,
+  start_at,
+  end_at,
+  reserve_price,
+  buy_now_price,
+  status = 'active'
+}) {
   const query = `
-    INSERT INTO auctions (title, description, user_id, category, start_at, end_at, status)
-    VALUES ($1, $2, $3, $4, NOW(), $5, 'active')
-    RETURNING id, title, description, user_id, category, start_at, end_at, status;
+    INSERT INTO auctions (
+      title,
+      description,
+      user_id,
+      category,
+      image_url,
+      start_at,
+      end_at,
+      reserve_price,
+      buy_now_price,
+      status
+    )
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+    RETURNING id, title, description, user_id, category, image_url, start_at, end_at, reserve_price, buy_now_price, status;
   `;
-  const params = [title, description, user_id, category, end_at];
+  const params = [
+    title,
+    description,
+    user_id,
+    category,
+    image_url,
+    start_at || new Date(),
+    end_at,
+    reserve_price,
+    buy_now_price,
+    status
+  ];
   const { rows } = await db.query(query, params);
   return rows[0];
 }
 
 async function getActiveAuctions() {
   const query = `
-    SELECT id, title, description, user_id, category, start_at, end_at, status
+    SELECT id, title, description, user_id, category, image_url, start_at, end_at, reserve_price, buy_now_price, status
     FROM auctions
     WHERE status = 'active' AND end_at > NOW();
   `;
@@ -23,7 +56,7 @@ async function getActiveAuctions() {
 
 async function getAuctionsByUser(userId) {
   const query = `
-    SELECT id, title, description, user_id, category, start_at, end_at, status
+    SELECT id, title, description, user_id, category, image_url, start_at, end_at, reserve_price, buy_now_price, status
     FROM auctions
     WHERE user_id = $1 AND end_at > NOW();
   `;


### PR DESCRIPTION
## Summary
- allow `createAuction` to handle category, image_url, start/end times, and price fields
- add seeding script with sample users, auctions, and bids
- include pg dependency for database access

## Testing
- `npm test`
- `node seed.js` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68a16405702c832897a7a9fa60d5588e